### PR TITLE
fix: hot zone for click event in search box

### DIFF
--- a/src/components/header/components/DocSearchRes.tsx
+++ b/src/components/header/components/DocSearchRes.tsx
@@ -71,8 +71,8 @@ const DocSearchRes = (props: IDocSearchResProps) => {
         >
           {data.title}
           <Divider type='vertical' />
-          <Source src={data.htmlUrl} />
         </span>
+        <Source src={data.htmlUrl} />
         <Divider />
       </div>
     ));

--- a/src/components/header/components/ExampleSearchRes.tsx
+++ b/src/components/header/components/ExampleSearchRes.tsx
@@ -71,8 +71,8 @@ const ExampleSearchRes = (props: IExampleSearchResProps) => {
         >
           {data.title}
           <Divider type='vertical' />
-          <Source src={data.htmlUrl} />
         </span>
+        <Source src={data.htmlUrl} />
         <Divider />
       </div>
     ));


### PR DESCRIPTION
confine the hot zone for click event in search box as follows:
![image](https://user-images.githubusercontent.com/40831966/199679778-38f04b40-6d3c-45b5-912b-3f8df51ec81f.png)
