### PR TITLE
refactor: homepage styles

### DIFF
--- a/src/components/header/index.less
+++ b/src/components/header/index.less
@@ -1,9 +1,11 @@
 .header {
   position: relative;
   z-index: 10;
-  height: 64px;
-  background-color: #fff;
+  background-color: #ffffff;
   box-shadow: 0 2px 8px #f0f1f2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #logo {
@@ -26,21 +28,6 @@
   }
 }
 
-.header-meta {
-  padding-right: 40px;
-}
-
-.header-meta::before {
-  display: table;
-  content: '';
-}
-
-.header-meta::after {
-  display: table;
-  clear: both;
-  content: '';
-}
-
 #search-box {
   float: left;
   height: 22px;
@@ -56,7 +43,7 @@
   }
 
   input {
-    width:240px;
+    width:200px;
     font-size: 14px;
     background: transparent;
     border: 0;
@@ -69,24 +56,22 @@
 }
 
 #menu {
-  .ant-menu {
-    line-height: 64px;
-  }
-
+  margin-left: 20px;
   .ant-menu-horizontal {
     border-bottom: none;
+  }
+  .ant-menu-item,
+  .ant-menu-submenu {
+    padding: 0 10px;
   }
 }
 
 .right-header {
-  float: right;
-  padding: 20px;
-  overflow: hidden;
-
-  & > * {
-    display: inline-block;
-    margin-right: 16px;
-  }
+  padding-left: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -155,42 +155,34 @@ function Header() {
               <MenuOutlined className='nav-phone-icon' />
             </Popover>
           )}
-          <Row>
-            <Col xxl={4} xl={5} lg={8} md={8} sm={24} xs={24}>
-              <Link id='logo' to='/'>
-                <img src={LOGO_URL} alt='Oasis Engine' />
-              </Link>
-            </Col>
-            <Col xxl={20} xl={19} lg={16} md={16} sm={0} xs={0}>
-              {!isMobile && <SearchBox></SearchBox>}
-              <div className='header-meta'>
-                {!isMobile && (
-                  <div className='right-header'>
-                    <div id='lang'>
-                      <Button
-                        size='small'
-                        onClick={() => {
-                          context.setLang(context.lang === 'zh-CN' ? 'en' : 'zh-CN');
-                        }}
-                      >
-                        <FormattedMessage id='app.header.lang' />
-                      </Button>
-                    </div>
-                    <Select size='small' onChange={(e) => context.setVersion(e)} value={context.version}>
-                      {versions.map((v) => {
-                        return (
-                          <Option value={v} key={v}>
-                            {v}
-                          </Option>
-                        );
-                      })}
-                    </Select>
-                  </div>
-                )}
-                <div id='menu'>{getMenu(false)}</div>
+          <Link id='logo' to='/'>
+            <img src={LOGO_URL} alt='Oasis Engine' />
+          </Link>
+          {!isMobile && <SearchBox></SearchBox>}
+          {!isMobile && <div id='menu'>{getMenu(false)}</div>}
+          {!isMobile && (
+            <div className='right-header'>
+              <div id='lang'>
+                <Button
+                  size='small'
+                  onClick={() => {
+                    context.setLang(context.lang === 'zh-CN' ? 'en' : 'zh-CN');
+                  }}
+                >
+                  <FormattedMessage id='app.header.lang' />
+                </Button>
               </div>
-            </Col>
-          </Row>
+              <Select size='small' onChange={(e) => context.setVersion(e)} value={context.version}>
+                {versions.map((v) => {
+                  return (
+                    <Option value={v} key={v}>
+                      {v}
+                    </Option>
+                  );
+                })}
+              </Select>
+            </div>
+          )}
         </div>
       )}
     </Media>

--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -18,29 +18,29 @@ function Banner() {
               alt='Oasis Engine'
             />
           </h1>
-          <div className='description'>
+          <div className='home-description'>
             <FormattedMessage id='app.home.slogan' />
-            <a href="https://github.com/ant-galaxy/oasis-engine/stargazers" target='_blank' style={{ marginLeft: "10px" }} >
+            <a href="https://github.com/ant-galaxy/oasis-engine/stargazers" target='_blank'>
               <img src="https://img.shields.io/github/stars/ant-galaxy/oasis-engine?style=social" alt="github stars" />
             </a>
-            <a href="https://www.npmjs.com/package/oasis-engine" target='_blank' style={{ marginLeft: "10px" }} >
+            <a href="https://www.npmjs.com/package/oasis-engine" target='_blank'>
               <img src="https://img.shields.io/npm/dm/oasis-engine.svg" alt="npm download" />
             </a>
           </div>
-          <div className='button-wrapper'>
+          <div className='home-button-wrapper'>
             <Link to={`/docs/${context.lang}`}>
               <Button type='primary'>
                 <FormattedMessage id='app.home.start' />
                 <ArrowRightOutlined style={{ marginLeft: "5px" }} />
               </Button>
             </Link>
-            <a href='https://github.com/ant-galaxy/oasis-engine/discussions/categories/q-a' target='_blank' style={{ marginLeft: "10px" }}>
+            <a href='https://github.com/ant-galaxy/oasis-engine/discussions/categories/q-a' target='_blank'>
               <Button type='primary' ghost>
                 <GithubOutlined style={{ marginRight: "5px" }} />
                 <FormattedMessage id='app.home.discussion' />
               </Button>
             </a>
-            <a href='https://opencollective.com/oasis' target='_blank' style={{ marginLeft: "10px" }}>
+            <a href='https://opencollective.com/oasis' target='_blank'>
               <Button>
                 <HeartFilled style={{ color: "hotpink", marginRight: "5px" }} />
                 <FormattedMessage id='app.home.sponsoring' />

--- a/src/components/home/index.less
+++ b/src/components/home/index.less
@@ -128,48 +128,20 @@
     font-size: 20px;
   }
 
-  .github-btn {
-    display: inline-block;
-    height : 28px;
-
-    .gh-btn {
-      display      : flex;
-      align-items  : center;
-      height       : 28px;
-      padding      : 0 12px;
-      font-size    : 13px;
-      background   : #f3f3f3;
-      background   : linear-gradient(to bottom, #ffffff 0%, #f3f3f3 100%);
-      border       : 1px solid #ebedf0;
-      border-radius: 4px;
-
-      &:hover {
-        color: #1890ff;
-
-      }
-
-      .gh-ico {
-        margin-right: 8px;
-      }
-    }
-
-    .gh-count {
-      height       : 28px;
-      padding      : 2px 8px;
-      font-size    : 13px;
-      line-height  : 22px;
-      background   : #fff;
-      border       : 1px solid #ebedf0;
-      border-radius: 4px;
-    }
-  }
-
-  .button-wrapper {
+  .home-button-wrapper {
     display        : flex;
     align-items    : center;
     justify-content: center;
+    gap            : 10px;
     margin-top     : 40px;
     line-height    : 40px;
+  }
+
+  .home-description {
+    display        : flex;
+    align-items    : center;
+    justify-content: center;
+    gap            : 10px;
   }
 }
 
@@ -183,9 +155,20 @@
     width  : auto;
   }
 
-  .home-section-banner h1 img {
-    width: 100%;
+  .home-section-banner {
+    h1 {
+      font-size: 28px;
+
+      img {
+        width: 100%;
+      }
+    }
+
+    p {
+      font-size: 16px;
+    }
   }
+
 
   .home-section-advantage .home-flex {
     padding     : 20px 70px;
@@ -195,15 +178,15 @@
 
   .home-section-features {
     flex-direction: row;
+
+    .home-flex-feature {
+      padding: 20px 0;
+    }
   }
 
   .home-section-features canvas {
     width : 100vw !important;
     height: 100vw !important;
-  }
-
-  .home-section-features .home-flex-feature {
-    padding: 20px 0;
   }
 
   .home-banner-image {
@@ -216,18 +199,6 @@
 
   .home-page {
     width: 90%;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .home-section-banner {
-    h1 {
-      font-size: 28px;
-    }
-
-    p {
-      font-size: 16px;
-    }
   }
 
   .home-section {
@@ -244,5 +215,15 @@
 
   .home-section-partners {
     padding: 2rem 0;
+  }
+
+  .home-section-banner {
+    .home-button-wrapper {
+      flex-direction: column;
+    }
+  }
+
+  .home-description {
+    flex-direction: column;
   }
 }

--- a/src/components/home/index.less
+++ b/src/components/home/index.less
@@ -108,7 +108,6 @@
 }
 
 .home-section-banner {
-  padding   : 40px 0;
   text-align: center;
 }
 
@@ -202,28 +201,29 @@
   }
 
   .home-section {
-    padding-top: 0;
+    padding  : 10px 0 0 0;
 
     h2 {
       font-size: 24px;
     }
   }
 
-  .home-flex-case {
+  .home-section-partners {
     padding: 10px;
   }
 
-  .home-section-partners {
-    padding: 2rem 0;
+  .home-flex-case {
+    padding: 10px;
   }
 
   .home-section-banner {
     .home-button-wrapper {
       flex-direction: column;
+      gap           : 20px;
     }
-  }
 
-  .home-description {
-    flex-direction: column;
+    .home-description {
+      flex-direction: column;
+    }
   }
 }

--- a/src/constants/locale.ts
+++ b/src/constants/locale.ts
@@ -127,7 +127,7 @@ export const translationsData: { [lang: string]: any } = {
     'app.content.loading': 'Loading...',
     'app.header.search': 'Search...',
     'app.header.search.loading': 'Loading...',
-    'app.header.search.box': 'Search Documenation/Examples/API',
+    'app.header.search.box': 'Search Docs/Examples/API',
     'app.header.search.no-matching':'No matching result',
     'app.header.search.all': 'Search in Google: ',
     'app.header.search.doc': 'Docs',


### PR DESCRIPTION
- 首屏样式适配了移动端
<img width="447" alt="image" src="https://user-images.githubusercontent.com/1296667/199880741-c0d21126-1f01-432c-b51c-b41e1d160ab4.png">
- header 样式做了小幅重构，现在看起来更紧凑，在窄屏下避免菜单出现省略号
<img width="1288" alt="image" src="https://user-images.githubusercontent.com/1296667/199880976-a0f4b4de-2ae8-4d29-b364-c5a192a1829f.png">