### PR TITLE
feat: save language settings in local storage

### DIFF
--- a/src/components/contextProvider/index.tsx
+++ b/src/components/contextProvider/index.tsx
@@ -12,7 +12,10 @@ export const AppContext = createContext<AppContext>(defaultValue);
 AppContext.displayName = 'AppContext';
 
 const AppContextProvider = (props: PropsWithChildren) => {
-  const [lang, setLang] = useState<'zh-CN' | 'en'>(navigator.language.includes('en') ? 'en' : 'zh-CN');
+  const localStorageLang = localStorage.getItem('lang') === 'en' ? 'en' : 'zh-CN';
+  const [lang, setLang] = useState<'zh-CN' | 'en'>(
+    localStorageLang || (navigator.language.includes('en') ? 'en' : 'zh-CN')
+  );
   const [version, setVersion] = useState('latest');
   return (
     <AppContext.Provider value={{ lang, setLang, version, setVersion }}>{props.children}</AppContext.Provider>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -8,7 +8,7 @@ import {
   ReadOutlined,
   TwitterOutlined,
   YuqueOutlined,
-  ZhihuOutlined
+  ZhihuOutlined,
 } from '@ant-design/icons';
 import { Button, Col, Menu, Popover, Row, Select } from 'antd';
 import { useContext } from 'react';
@@ -166,7 +166,9 @@ function Header() {
                 <Button
                   size='small'
                   onClick={() => {
-                    context.setLang(context.lang === 'zh-CN' ? 'en' : 'zh-CN');
+                    const newLang = context.lang === 'zh-CN' ? 'en' : 'zh-CN';
+                    context.setLang(newLang);
+                    localStorage.setItem('lang', newLang);
                   }}
                 >
                   <FormattedMessage id='app.header.lang' />

--- a/src/siteconfig.json
+++ b/src/siteconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "oasis-engine",
   "version": "0.9",
-  "versions": ["latest"],
+  "versions": ["latest", "0.8"],
   "serverConfig": {
     "local": "http://oasisbe-afx-38287.gz00b.dev.alipay.net",
     "dev": "http://oasisbe-afx-38287.gz00b.dev.alipay.net",


### PR DESCRIPTION
Save language settings in local storage;
Init website from local storage first, if not available,  then use browser language settings