### PR TITLE
fix: logo style

### DIFF
--- a/src/components/header/index.less
+++ b/src/components/header/index.less
@@ -9,10 +9,6 @@
 }
 
 #logo {
-  float: left;
-  height: 64px;
-  padding-left: 40px;
-  overflow: hidden;
   line-height: 64px;
   text-decoration: none;
 


### PR DESCRIPTION
logo 的 padding-left 应该是 0，有一些多余的样式清理掉。之前 https://github.com/ant-galaxy/oasis-engine.github.io/pull/507 遗漏了。