### PR TITLE
fix: reset page state when version changes

### DIFF
--- a/src/components/Api/index.tsx
+++ b/src/components/Api/index.tsx
@@ -38,6 +38,10 @@ const Api = () => {
 
   // page init: get package list; set selected package
   useEffect(() => {
+    setSelectedItem(undefined);
+    setPkgChildren([]);
+    setChildrenDetail(null);
+    setPkgList([]);
     navigate(
       `/api/${version}/${selectedPkg}${
         selectedItem ? '/' + pkgChildren.find((child) => child.id === selectedItem)?.name : ''

--- a/src/components/Examples/index.tsx
+++ b/src/components/Examples/index.tsx
@@ -41,6 +41,10 @@ export default function Examples() {
   }, [version]);
 
   useEffect(() => {
+    setSelectedExampleId('');
+    setItems([]);
+    setFilteredItems([]);
+    menuKeyTitleMapRef.current.clear();
     navigate(`/examples/${context.version}`);
     fetchMenuList('ts', context.version).then((list) => {
       const itemRes: ItemType[] = [];
@@ -69,22 +73,20 @@ export default function Examples() {
           }
           itemRes.push(newRootMenu);
         });
-      if (!selectedExampleId) {
-        // init routing from path params
-        if (exampleTitle) {
-          for (let [key, value] of menuKeyTitleMapRef.current.entries()) {
-            if (value === exampleTitle) {
-              setSelectedExampleId(key);
-              break;
-            }
+      // init routing from path params
+      if (exampleTitle && Array.from(menuKeyTitleMapRef.current.values()).includes(exampleTitle)) {
+        for (let [key, value] of menuKeyTitleMapRef.current.entries()) {
+          if (value === exampleTitle) {
+            setSelectedExampleId(key);
+            break;
           }
-          // init routing by default first doc
-        } else {
-          const defaultSelectedDocId =
-            (itemRes[0] as any)?.children?.[0]?.children?.[0]?.key || (itemRes[0] as any)?.children?.[0].key;
-          if (defaultSelectedDocId) {
-            setSelectedExampleId(defaultSelectedDocId);
-          }
+        }
+        // init routing by default first doc
+      } else {
+        const defaultSelectedDocId =
+          (itemRes[0] as any)?.children?.[0]?.children?.[0]?.key || (itemRes[0] as any)?.children?.[0].key;
+        if (defaultSelectedDocId) {
+          setSelectedExampleId(defaultSelectedDocId);
         }
       }
       setItems(itemRes);

--- a/src/components/Playground/index.tsx
+++ b/src/components/Playground/index.tsx
@@ -23,8 +23,8 @@ export default function Playground(props: IPlayground) {
   const url = `/#/example/${props.id}`;
   const iframe = createRef<HTMLIFrameElement>();
 
-  const fetchCode = async () => {
-    const res = await fetchDocDataById(props.id);
+  const fetchCode = async (id: string) => {
+    const res = await fetchDocDataById(id);
 
     const code = Prism.highlight(res?.content || '', Prism.languages.javascript, 'javascript');
     setCode(code);
@@ -32,7 +32,8 @@ export default function Playground(props: IPlayground) {
   };
 
   useEffect(() => {
-    fetchCode();
+    if (!props.id) return;
+    fetchCode(props.id);
 
     // fix: iframe not reload when url hash changes
     iframe.current?.contentWindow?.location.reload();
@@ -49,7 +50,7 @@ export default function Playground(props: IPlayground) {
     fetchDependencies();
   }, [version]);
 
-  if (!packages) return null;
+  if (!packages || !props.id) return null;
 
   return (
     <div className='code-box'>


### PR DESCRIPTION
change list:
1, when users switch versions on API and Example page, the page state need to be refreshed so that the page content can be reloaded.
2, when the URL contains an example title on Example page, the page need to be initialized from the example title.