### PR TITLE
feat: add plugin in build to replace CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ yarn dev
 ```bash
 yarn playground
 ```
-## Deploy
+## Build
 ```bash
 $ yarn build
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ yarn playground
 ```bash
 $ yarn build
 ```
+## Deploy
+```bash
+$ yarn deploy
+```
 
 ## Q&A
 #### How to insert a playground in markdown

--- a/README.md
+++ b/README.md
@@ -13,12 +13,9 @@ $ yarn dev
 ```bash
 yarn playground
 ```
-## Build
-```bash
-$ yarn build
-```
 ## Deploy
 ```bash
+$ yarn build
 $ yarn deploy
 ```
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Oasis Engine - 移动优先的高性能 Web 互动引擎</title>
+    <title>Oasis Engine - Mobile first high performance web interactive engine</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
-    "test": "node scripts/test.js",
+    "deploy": "gh-pages -d dist",
     "playground": "vite serve playground/.dev --config playground/.dev/vite.config.js"
   },
   "eslintConfig": {
@@ -89,6 +89,7 @@
     "@types/react-scroll": "^1.8.4",
     "@types/react-syntax-highlighter": "^15.5.5",
     "fs-extra": "^10.1.0",
+    "gh-pages": "^4.0.0",
     "less": "^4.1.3",
     "sass": "^1.55.0"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,6 +47,9 @@ export default ({ mode }) => {
             'oasis-engine': ['oasis-engine'],
             '@oasis-engine/spine': ['@oasis-engine/spine'],
             '@babel/standalone': ['@babel/standalone']
+          },
+          chunkFileNames() {
+            return 'assets/modules/[name]-[hash].js'
           }
         },
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,26 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import * as fs from 'fs';
+
+function replaceCDN() {
+  return {
+    name: 'vite-replace-cdn',
+    closeBundle() {
+      const entryHTML = 'dist/index.html';
+      const CDNPath = "//cdn.jsdelivr.net/gh/ant-galaxy/oasis-engine.github.io@gh-pages/assets/";
+
+      let text = fs.readFileSync(entryHTML, {
+        encoding: 'utf8'
+      });
+
+      text = text.replace(/\/assets\//g, CDNPath);
+
+      fs.writeFileSync(entryHTML, text, {
+        encoding: 'utf8'
+      });
+    }
+  }
+}
 
 export default ({ mode }) => {
   return defineConfig({
@@ -8,7 +29,10 @@ export default ({ mode }) => {
       host: "0.0.0.0",
       port: 3333
     },
-    plugins: [react()],
+    plugins: [
+      react(),
+      replaceCDN()
+    ],
     define: {
       "process.env.NODE_ENV": `"${mode}"`,
     },
@@ -22,7 +46,7 @@ export default ({ mode }) => {
             '@oasis-engine/spine': ['@oasis-engine/spine'],
             '@babel/standalone': ['@babel/standalone']
           }
-        }
+        },
       }
     }
   })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,8 @@ function replaceCDN() {
       fs.writeFileSync(entryHTML, text, {
         encoding: 'utf8'
       });
+
+      fs.copyFileSync('CNAME', 'dist/CNAME')
     }
   }
 }


### PR DESCRIPTION
- [x] Use **jsdelivr** CDN to accelerate assets loading.
- [x] Add a **deploy** script for deployment of github pages.