### PR TITLE
Fix playground link bug

### DIFF
--- a/playground/.dev/vite.config.js
+++ b/playground/.dev/vite.config.js
@@ -58,6 +58,11 @@ module.exports = {
     host: "0.0.0.0",
     port: 3000
   },
+  resolve:{
+    dedupe:[
+      "oasis-engine"
+    ]
+  },
   optimizeDeps: {
     exclude: [
       "oasis-engine",


### PR DESCRIPTION
Playground link `oasis-engine` and `oasis-engine-toolkit` will load two `oasis-engine`, event `oasis-engine-toolkit` is peerdenpents `oasis-engine`.

Solve with ads a config param in vite:
```
resolve:{
    dedupe:[
      "oasis-engine"
    ]
  }
```