### PR TITLE
fix search bugs

### DIFF
--- a/src/components/Examples/index.tsx
+++ b/src/components/Examples/index.tsx
@@ -33,6 +33,7 @@ const StyledContent = styled("div", {
 
 const StyledNav = styled("nav", {
   height: 'calc(100vh - 61px)',
+  width: "250px",
   overflow: "auto",
   borderRight: "1px solid $slate5"
 })
@@ -163,7 +164,10 @@ export default function Examples() {
         newGroup.children = (group as any).children.filter((i: { label: string }) =>
           i.label?.toLocaleLowerCase().includes(search?.toLocaleLowerCase())
         );
-        filtered.push(newGroup);
+
+        if (newGroup.children.length > 0) {
+          filtered.push(newGroup);
+        }
       });
       setFilteredItems(filtered);
     }

--- a/src/components/doc/index.tsx
+++ b/src/components/doc/index.tsx
@@ -1,6 +1,3 @@
-import { MenuUnfoldOutlined } from '@ant-design/icons';
-import { Affix, Col, Popover, Row } from 'antd';
-import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import mermaid from 'mermaid'
 import { List } from 'iconoir-react';
 import { useContext, useEffect, useRef, useState } from 'react';

--- a/src/components/header/components/SearchResults.tsx
+++ b/src/components/header/components/SearchResults.tsx
@@ -62,7 +62,8 @@ const SearchResult = (props: ISearchResProps) => {
               content: props.searchText,
               pageSize: PAGE_SIZE,
               pageNo: "0",
-              lang: context.lang,
+              type: "markdown",
+              lang: context.lang
             }),
             categoryReg: /\ntype:(.+)\n/,
             link: (data: any) => `/docs/${context.version}/${context.lang}/${data.filename.slice(0, -3)}`,
@@ -84,7 +85,7 @@ const SearchResult = (props: ISearchResProps) => {
               content: props.searchText,
               pageSize: PAGE_SIZE,
               pageNo: "0",
-              lang: context.lang,
+              type: "ts"
             }),
             categoryReg: /\n\s?[*]\s?@category(.+)\n/,
             link: (data: any) => `/examples/${context.version}/${data.filename.slice(0, -3)}`,

--- a/src/components/header/headerUtils.ts
+++ b/src/components/header/headerUtils.ts
@@ -14,10 +14,11 @@ interface APISearchOptions {
 interface DocSearchOptions {
   content: string;
   title: string;
-  lang: string;
   version: string;
   pageNo: string;
   pageSize: string;
+  type: string;
+  lang?: string;
 }
 
 export interface APISearchResponse {


### PR DESCRIPTION
- fix: examples not found when search in search bar of header.
- fix: hide the category when there is no search results in the examples page.