### PR TITLE
Adapt new search API

### DIFF
--- a/src/components/header/components/SearchResult.tsx
+++ b/src/components/header/components/SearchResult.tsx
@@ -91,7 +91,8 @@ const DocSearchRes = (props: IDocSearchResProps) => {
   docList.forEach((data: any) => {
     let category = props.category;
 
-    if (category) {
+    // TODO:  && !data.content 兼容老搜索接口
+    if (category && !data.content) {
       const type = data[category];
 
       if (!typedDocs[type]) {

--- a/src/components/header/components/SearchResults.tsx
+++ b/src/components/header/components/SearchResults.tsx
@@ -65,6 +65,7 @@ const SearchResult = (props: ISearchResProps) => {
               type: "markdown",
               lang: context.lang
             }),
+            category: "category",
             categoryReg: /\ntype:(.+)\n/,
             link: (data: any) => `/docs/${context.version}/${context.lang}/${data.filename.slice(0, -3)}`,
             setLoadingSearchResult: props.setLoadingSearchResult,
@@ -87,6 +88,7 @@ const SearchResult = (props: ISearchResProps) => {
               pageNo: "0",
               type: "ts"
             }),
+            category: "category",
             categoryReg: /\n\s?[*]\s?@category(.+)\n/,
             link: (data: any) => `/examples/${context.version}/${data.filename.slice(0, -3)}`,
             setLoadingSearchResult: props.setLoadingSearchResult,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,7 +45,8 @@ export default ({ mode }) => {
           manualChunks: {
             'oasis-engine': ['oasis-engine'],
             '@oasis-engine/spine': ['@oasis-engine/spine'],
-            '@babel/standalone': ['@babel/standalone']
+            '@babel/standalone': ['@babel/standalone'],
+            'mermaid': ['mermaid']
           },
           chunkFileNames() {
             return 'assets/modules/[name]-[hash].js'


### PR DESCRIPTION
- Adapt new search API: remove `content` field and add a `category` field.
- [external mermaid](https://github.com/ant-galaxy/oasis-engine.github.io/commit/326500c836224d4e548272ccb6f983bb0e06299b) because `mermaid` library is too large.