### PR TITLE
Refactor: docs url

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,8 +18,10 @@ function App() {
     }});
   }, []);
 
+  const lang = context.lang === 'cn' ? 'zh-CN' : 'en';
+
   return (
-    <IntlProvider locale={context.lang} messages={translationsData[context.lang]}>
+    <IntlProvider locale={lang} messages={translationsData[lang]}>
       <TooltipProvider>
         <RouterProvider router={router} fallbackElement={<LoadingIcon />}></RouterProvider>
       </TooltipProvider>

--- a/src/components/Api/index.tsx
+++ b/src/components/Api/index.tsx
@@ -195,10 +195,8 @@ const Api = () => {
   let { version } = useContext(AppContext);
   const [pkgChildren, setPkgChildren] = useState<PkgChild[]>();
   const navigate = useNavigate();
-  console.log(version, pkg, name)
 
-  if (!version || !pkg) {
-    version = version || 'latest';
+  if (!pkg) {
     pkg = pkg || 'core';
     navigate(`/api/${version}/${pkg}`);
   }

--- a/src/components/contextProvider/index.tsx
+++ b/src/components/contextProvider/index.tsx
@@ -1,7 +1,7 @@
 import { createContext, PropsWithChildren, useState } from 'react';
 
 interface AppContext {
-  lang: 'zh-CN' | 'en';
+  lang: 'cn' | 'en';
   version: string;
   theme: string;
   setLang: Function;
@@ -10,7 +10,7 @@ interface AppContext {
 }
 
 const defaultValue: AppContext = {
-  lang: 'zh-CN',
+  lang: 'cn',
   version: 'latest',
   theme: "light-theme",
   setLang: () => {},
@@ -22,10 +22,10 @@ export const AppContext = createContext<AppContext>(defaultValue);
 AppContext.displayName = 'AppContext';
 
 const AppContextProvider = (props: PropsWithChildren) => {
-  const localStorageLang = localStorage.getItem('lang') === 'en' ? 'en' : 'zh-CN';
+  const localStorageLang = localStorage.getItem('lang') === 'en' ? 'en' : 'cn';
   const localStorageTheme = localStorage.getItem('theme') === 'dark-theme' ? 'dark-theme' : 'light-theme';
-  const [lang, setLang] = useState<'zh-CN' | 'en'>(
-    localStorageLang || (navigator.language.includes('en') ? 'en' : 'zh-CN')
+  const [lang, setLang] = useState<'cn' | 'en'>(
+    localStorageLang || (navigator.language.includes('en') ? 'en' : 'cn')
   );
   const [version, setVersion] = useState('latest');
   const [theme, setTheme] = useState(localStorageTheme);

--- a/src/components/doc/components/DocDetail.tsx
+++ b/src/components/doc/components/DocDetail.tsx
@@ -268,7 +268,7 @@ function DocDetail(props: PropsWithChildren<DocDetailProps>) {
               if (typeof linkHref === 'string' && linkHref.startsWith('/#/docs/')) {
                 return (
                   <Link
-                    to={`/docs/${version}/${lang === 'en' ? 'en' : 'cn'}/${linkHref.replace('/#/docs/', '')}${lang === 'cn' && !linkHref.endsWith('.zh-CN') ? '.zh-CN' : ''}`}
+                    to={`/docs/${version}/${lang === 'en' ? 'en' : 'cn'}/${linkHref.replace('/#/docs/', '')}`}
                   >
                     {title}
                   </Link>

--- a/src/components/doc/components/DocDetail.tsx
+++ b/src/components/doc/components/DocDetail.tsx
@@ -268,7 +268,7 @@ function DocDetail(props: PropsWithChildren<DocDetailProps>) {
               if (typeof linkHref === 'string' && linkHref.startsWith('/#/docs/')) {
                 return (
                   <Link
-                    to={`/docs/${version}/${lang === 'en' ? 'en' : 'cn'}/${linkHref.replace('/#/docs/', '')}${lang === 'zh-CN' && !linkHref.endsWith('.zh-CN') ? '.zh-CN' : ''}`}
+                    to={`/docs/${version}/${lang === 'en' ? 'en' : 'cn'}/${linkHref.replace('/#/docs/', '')}${lang === 'cn' && !linkHref.endsWith('.zh-CN') ? '.zh-CN' : ''}`}
                   >
                     {title}
                   </Link>

--- a/src/components/doc/index.tsx
+++ b/src/components/doc/index.tsx
@@ -4,7 +4,7 @@ import { useContext, useEffect, useRef, useState } from 'react';
 import Media from 'react-media';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ActionButton } from '@oasis-engine/editor-components';
-import { styled } from  "@oasis-engine/editor-design-system";
+import { styled } from "@oasis-engine/editor-design-system";
 import { Flex } from '@oasis-engine/editor-components';
 import { Popover } from '@oasis-engine/editor-components';
 import { AppContext } from '../contextProvider';
@@ -32,35 +32,76 @@ function Doc() {
   const context = useContext(AppContext);
   const [selectedDocId, setSelectedDocId] = useState('');
   const [items, setItems] = useState<any[]>([]);
-  const { ver, docTitle, lang } = useParams();
+  let { ver, docTitle, lang } = useParams();
   const languageCode = lang === 'en' ? 'en' : 'zh-CN';
   const navigate = useNavigate();
   const menuKeyTitleMapRef = useRef<Map<string, string>>(new Map());
+
+  const setSelectedItem = (docTitle: string) => {
+    let title = docTitle;
+
+    if (lang === 'cn') {
+      title += '.zh-CN'
+    }
+    // init routing from path params
+    if (Array.from(menuKeyTitleMapRef.current.values()).includes(title)) {
+      for (let [key, value] of menuKeyTitleMapRef.current.entries()) {
+        if (value === title) {
+          setSelectedDocId(key);
+          break;
+        }
+      }
+    }
+  }
+
+  if (!ver || !docTitle) {
+    // set default version
+    if (!ver) {
+      ver = context.version;
+    }
+
+    // set default 
+    if (!docTitle) {
+      docTitle = 'install';
+    }
+
+    navigate(`/docs/${ver}/${context.lang}/${docTitle}`);
+  }
 
   useEffect(() => {
     mermaid.initialize({
       startOnLoad: true,
     })
   }, [])
-  
-  
+
   useEffect(() => {
-    const currentSelectedDocTitle = menuKeyTitleMapRef.current.get(selectedDocId);
+    // when route changes
+    if (docTitle) {
+      setSelectedItem(docTitle);
+    }
+  }, [docTitle])
+
+  useEffect(() => {
+    // navigate to new url if selectedDocId changes
+    if (selectedDocId) {
+      const selectedDocTitle = menuKeyTitleMapRef.current.get(selectedDocId);
+
+      if (selectedDocTitle) {
+        let title = selectedDocTitle.replace('.zh-CN', '');
+
+        navigate(`/docs/${ver}/${context.lang}/${title}`);
+      }
+    }
+  }, [selectedDocId]);
+
+  useEffect(() => {
+    // navigate to new url if version or lang change.
     navigate(
-      `/docs/${context.version}/${context.lang === 'en' ? 'en' : 'zh'}/${context.lang === 'en'
-        ? currentSelectedDocTitle?.replace('.zh-CN', '')
-        : currentSelectedDocTitle + '.zh-CN'
-      }`
+      `/docs/${context.version}/${context.lang === 'en' ? 'en' : 'cn'}/${docTitle}`
     );
-    setItems([]);
-  }, [context.lang, context.version]);
 
-  useEffect(() => {
-    context.setVersion(ver);
-  }, [ver]);
-
-  useEffect(() => {
     menuKeyTitleMapRef.current.clear();
+
     fetchMenuList('markdown', context.version).then((list) => {
       const itemRes: any[] = [];
       list
@@ -101,46 +142,11 @@ function Doc() {
             });
           itemRes.push(newRootMenu);
         });
-      // init routing from path params
-      if (docTitle && Array.from(menuKeyTitleMapRef.current.values()).includes(docTitle)) {
-        for (let [key, value] of menuKeyTitleMapRef.current.entries()) {
-          if (value === docTitle) {
-            setSelectedDocId(key);
-            break;
-          }
-        }
-        // init routing by default first doc
-      } else {
-        const defaultSelectedDocId =
-          (itemRes[0] as any)?.children?.[0]?.children?.[0]?.key || (itemRes[0] as any)?.children?.[0]?.key;
-        if (defaultSelectedDocId) {
-          setSelectedDocId(defaultSelectedDocId);
-          const selectedDocTitle = menuKeyTitleMapRef.current.get(defaultSelectedDocId);
-          selectedDocTitle &&
-            navigate(`/docs/${ver}/${context.lang === 'en' ? 'en' : 'zh'}/${selectedDocTitle}`);
-        }
-      }
-      setItems(itemRes);
-    });
-  }, [lang, context.version]);
 
-  useEffect(() => {
-    if (items.length === 0) {
-      return;
-    }
-    const selectedDocTitle = menuKeyTitleMapRef.current.get(selectedDocId);
-    if (!selectedDocTitle) {
-      return;
-    }
-    if (!docTitle && selectedDocId) {
-      navigate(`/docs/${ver}/${context.lang === 'en' ? 'en' : 'zh'}/${selectedDocTitle}`);
-      return;
-    }
-    if (docTitle && docTitle !== selectedDocTitle) {
-      setSelectedDocId(selectedDocId);
-      navigate(`/docs/${ver}/${context.lang === 'en' ? 'en' : 'zh'}/${selectedDocTitle}`);
-    }
-  }, [selectedDocId, items.length]);
+      setItems(itemRes);
+      setSelectedItem(docTitle);
+    });
+  }, [context.lang, context.version]);
 
   if (items.length === 0) {
     return <LoadingIcon></LoadingIcon>;
@@ -175,12 +181,12 @@ function Doc() {
                 <List />
               </ActionButton>
             }
-            sideOffset={6}
-            css={{
-              marginRight: "$4",
-              maxHeight: "70vh",
-              overflow: "auto"
-            }}>
+              sideOffset={6}
+              css={{
+                marginRight: "$4",
+                maxHeight: "70vh",
+                overflow: "auto"
+              }}>
               {menu}
             </Popover>
             <Footer></Footer>

--- a/src/components/doc/index.tsx
+++ b/src/components/doc/index.tsx
@@ -33,14 +33,13 @@ function Doc() {
   const [selectedDocId, setSelectedDocId] = useState('');
   const [items, setItems] = useState<any[]>([]);
   let { ver, docTitle, lang } = useParams();
-  const languageCode = lang === 'en' ? 'en' : 'zh-CN';
   const navigate = useNavigate();
   const menuKeyTitleMapRef = useRef<Map<string, string>>(new Map());
 
   const setSelectedItem = (docTitle: string) => {
     let title = docTitle;
 
-    if (lang === 'cn') {
+    if (context.lang === 'cn') {
       title += '.zh-CN'
     }
     // init routing from path params
@@ -54,21 +53,25 @@ function Doc() {
     }
   }
 
-  if (!ver || !docTitle) {
-    // set default version
-    if (!ver) {
-      ver = context.version;
-    }
-
-    // set default 
-    if (!docTitle) {
-      docTitle = 'install';
-    }
-
-    navigate(`/docs/${ver}/${context.lang}/${docTitle}`);
-  }
-
   useEffect(() => {
+    if (!ver || !docTitle) {
+      // set default version
+      if (!ver) {
+        ver = context.version;
+      }
+
+      if (!lang) {
+        lang = context.lang;
+      }
+
+      // set default 
+      if (!docTitle) {
+        docTitle = 'install';
+      }
+
+      navigate(`/docs/${ver}/${lang}/${docTitle}`);
+    }
+
     mermaid.initialize({
       startOnLoad: true,
     })
@@ -89,7 +92,7 @@ function Doc() {
       if (selectedDocTitle) {
         let title = selectedDocTitle.replace('.zh-CN', '');
 
-        navigate(`/docs/${ver}/${context.lang}/${title}`);
+        navigate(`/docs/${context.version}/${context.lang}/${title}`);
       }
     }
   }, [selectedDocId]);
@@ -102,6 +105,8 @@ function Doc() {
 
     menuKeyTitleMapRef.current.clear();
 
+    const languageCode = context.lang === 'en' ? 'en' : 'zh-CN';
+
     fetchMenuList('markdown', context.version).then((list) => {
       const itemRes: any[] = [];
       list
@@ -111,7 +116,7 @@ function Doc() {
           const { id, name, children, files, cn_name } = data;
           const newRootMenu: any = {
             key: id,
-            label: lang === 'en' ? name : cn_name,
+            label: context.lang === 'en' ? name : cn_name,
             children: [],
           };
           // create items
@@ -130,7 +135,7 @@ function Doc() {
           children
             .filter((item) => item.files.length > 0 || item.children.length > 0)
             .forEach((child, index) => {
-              let newGroup: any = { type: 'group', label: lang === 'en' ? child.name : child.cn_name };
+              let newGroup: any = { type: 'group', label: context.lang === 'en' ? child.name : child.cn_name };
               newGroup.children = child.files
                 .sort((a, b) => a.weight - b.weight)
                 .filter((file) => file.lang === languageCode && file.type === 'markdown')

--- a/src/components/doc/plugins/link.ts
+++ b/src/components/doc/plugins/link.ts
@@ -8,13 +8,13 @@ export default function linkPlugin() {
       if (url) {
         if (url.includes('${docs}')) {
           // TODO: replace with prod address here
-          node.url = decodeURIComponent(url).replace('${docs}', `/#/docs/`).replace('-cn', '.zh-CN');
+          node.url = decodeURIComponent(url).replace('${docs}', `/#/docs/`).replace('-cn', '');
         } else if (url.includes('${api}')) {
           // TODO: replace with prod address here
-          node.url = decodeURIComponent(url).replace('${api}', `/#/api/`).replace('-cn', 'zh-CN');
+          node.url = decodeURIComponent(url).replace('${api}', `/#/api/`);
         } else if (url.includes('${examples}')) {
           // TODO: replace with prod address here
-          node.url = decodeURIComponent(url).replace('${examples}', `/#/examples/`).replace('-cn', 'zh-CN');
+          node.url = decodeURIComponent(url).replace('${examples}', `/#/examples/`);
         }
       }
     });

--- a/src/components/doc/util/docUtil.ts
+++ b/src/components/doc/util/docUtil.ts
@@ -121,7 +121,7 @@ export interface FileData {
   type: string;
   /**
    * [文件语言]
-   * (enum: zh-CN, en, *)
+   * (enum: cn, en, *)
    */
   lang: string;
   /**

--- a/src/components/header/components/NavigationMenu.tsx
+++ b/src/components/header/components/NavigationMenu.tsx
@@ -306,10 +306,10 @@ const StyledNavigationMenu = () => {
               <ListItem to={`/docs/${context.version}/${context.lang}`} title={formatMessage({ id: 'app.header.menu.engine.docs' })}>
                 <FormattedMessage id='app.header.menu.engine.docs.description' />
               </ListItem>
-              <ListItem to={`/docs/latest/${context.lang}/artist-bake${context.lang === 'en' ? '' : '.zh-CN'}`} title={formatMessage({ id: 'app.header.menu.artist.docs' })}>
+              <ListItem to={`/docs/${context.version}/${context.lang}/artist-bake`} title={formatMessage({ id: 'app.header.menu.artist.docs' })}>
                 <FormattedMessage id='app.header.menu.artist.docs.description' />
               </ListItem>
-              <ListItem to={'/docs/latest/zh/editor.zh-CN'} title={formatMessage({ id: 'app.header.menu.editor.docs' })}>
+              <ListItem to={`/docs/${context.version}/cn/editor`} title={formatMessage({ id: 'app.header.menu.editor.docs' })}>
                 <FormattedMessage id='app.header.menu.editor.docs.description' />
               </ListItem>
             </StyledContentList>

--- a/src/components/header/components/NavigationMenuMobile.tsx
+++ b/src/components/header/components/NavigationMenuMobile.tsx
@@ -18,11 +18,11 @@ export function NavigationMenuMobile() {
         },
         {
           key: 1,
-          label: <Link to={`/docs/${context.version}/${context.lang}/artist-bake${context.lang === 'en' ? '' : '.zh-CN'}`}>{formatMessage({ id: 'app.header.menu.artist.docs' })}</Link>
+          label: <Link to={`/docs/${context.version}/${context.lang}/artist-bake`}>{formatMessage({ id: 'app.header.menu.artist.docs' })}</Link>
         },
         {
           key: 2,
-          label: <Link to={`/docs/${context.version}/zh/editor.zh-CN`} >{formatMessage({ id: 'app.header.menu.editor.docs' })}</Link>
+          label: <Link to={`/docs/${context.version}/cn/editor`} >{formatMessage({ id: 'app.header.menu.editor.docs' })}</Link>
         }
       ]
     },

--- a/src/components/header/components/SearchResults.tsx
+++ b/src/components/header/components/SearchResults.tsx
@@ -117,9 +117,7 @@ const SearchResult = (props: ISearchResProps) => {
               pageNo: "0"
             }),
             category: "kindString",
-            link: (data: any) => {
-            console.log('api data', data)
-             return `/api/${context.version}/core/${data.name}`},
+            link: (data: any) => `/api/${context.version}/core/${data.name}`,
             setLoadingSearchResult: props.setLoadingSearchResult,
             icon: <Puzzle />
           }}

--- a/src/components/header/components/SearchResults.tsx
+++ b/src/components/header/components/SearchResults.tsx
@@ -63,11 +63,19 @@ const SearchResult = (props: ISearchResProps) => {
               pageSize: PAGE_SIZE,
               pageNo: "0",
               type: "markdown",
-              lang: context.lang
+              lang: context.lang === 'cn' ? 'zh-CN' : 'en'
             }),
             category: "category",
             categoryReg: /\ntype:(.+)\n/,
-            link: (data: any) => `/docs/${context.version}/${context.lang}/${data.filename.slice(0, -3)}`,
+            link: (data: any) => {
+              let title = data.filename.slice(0, -3);
+
+              if (context.lang === 'cn') {
+                title = title.replace('.zh-CN', '');
+              }
+
+              return `/docs/${context.version}/${context.lang}/${title}`
+            },
             setLoadingSearchResult: props.setLoadingSearchResult,
             icon: <Book />
           }}
@@ -109,7 +117,9 @@ const SearchResult = (props: ISearchResProps) => {
               pageNo: "0"
             }),
             category: "kindString",
-            link: (data: any) => `/api/${context.version}/${data.name}`,
+            link: (data: any) => {
+            console.log('api data', data)
+             return `/api/${context.version}/core/${data.name}`},
             setLoadingSearchResult: props.setLoadingSearchResult,
             icon: <Puzzle />
           }}

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -48,7 +48,7 @@ function Header() {
       <ActionButton
         size="sm"
         onClick={() => {
-          const newLang = context.lang === 'zh-CN' ? 'en' : 'zh-CN';
+          const newLang = context.lang === 'cn' ? 'en' : 'cn';
           context.setLang(newLang);
           localStorage.setItem('lang', newLang);
         }}

--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -62,7 +62,7 @@ function Banner() {
           textAlign: "center"
         }
       }}>
-        <Link to={`/docs/latest/${context.lang}`}>
+        <Link to={`/docs/${context.version}/${context.lang}`}>
           <Button variant="primary">
             <FormattedMessage id='app.home.start' />
             <ArrowRightOutlined style={{ marginLeft: "5px" }} />

--- a/src/components/home/Features.tsx
+++ b/src/components/home/Features.tsx
@@ -23,7 +23,7 @@ const StyledFeature = styled(Flex, {
 });
 
 export default function Features() {
-  const { lang } = useContext(AppContext);
+  const { lang, version } = useContext(AppContext);
   return (
     <Flex align="both" gap="lg" css={{borderTop: "1px solid $slate5", padding: "$8 0"}}>
       <StyledFeature dir="column" gap="md" align="v">
@@ -32,7 +32,7 @@ export default function Features() {
         <p>
           <FormattedMessage id='app.home.3d.intro' />
         </p>
-        <Link to={`/docs/latest/${lang}/mesh-renderer`}>
+        <Link to={`/docs/${version}/${lang}/mesh-renderer`}>
           <Button variant='outline'>
             <FormattedMessage id='app.home.more' />
           </Button>
@@ -44,7 +44,7 @@ export default function Features() {
         <p>
           <FormattedMessage id='app.home.2d.intro' />
         </p>
-        <Link to={`/docs/latest/${lang}/mesh-renderer`}>
+        <Link to={`/docs/${version}/${lang}/sprite-renderer`}>
           <Button variant='outline'>
             <FormattedMessage id='app.home.more' />
           </Button>

--- a/src/constants/locale.ts
+++ b/src/constants/locale.ts
@@ -1,5 +1,5 @@
 export const translationsData: { [lang: string]: any } = {
-  'cn': {
+  'zh-CN': {
     'app.content.error.button': '回到首页',
     'app.content.error.subtitle': '页面异常',
     'app.content.loading': '努力加载中...',

--- a/src/constants/locale.ts
+++ b/src/constants/locale.ts
@@ -1,5 +1,5 @@
 export const translationsData: { [lang: string]: any } = {
-  'zh-CN': {
+  'cn': {
     'app.content.error.button': '回到首页',
     'app.content.error.subtitle': '页面异常',
     'app.content.loading': '努力加载中...',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ export function isZhCN() {
   if (typeof window !== 'undefined') {
     const local = window.localStorage.getItem('locale');
     return local
-      ? local === 'zh-CN'
+      ? local === 'cn'
       : window.navigator.language && window.navigator.language.toLocaleLowerCase() === 'zh-cn';
   }
 }


### PR DESCRIPTION
- Use `cn` instead of `zh-CN` in code.
- Remove `zh-CN` in url of docs：`docs/latest/cn/xxx.zh-CN  --> docs/latest/cn/xxx`
- Refactor logic of doc page.
- Fix: search results urls.